### PR TITLE
fix: unblock publish job on auto-incrementing release branch

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -76,6 +76,16 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org/"
+          # Do NOT run an immutable install here: this is a long-lived,
+          # auto-incrementing release branch. Its committed yarn.lock may lag the
+          # bumped package.json versions, and this job rewrites the lock anyway.
+          # An immutable install would fail before the version-bump/sync steps run.
+          install: "false"
+
+      - name: Install dependencies
+        # Mutable install: installs deps for nx/build AND self-heals any lockfile
+        # drift left by a previous release before this run bumps the version.
+        run: yarn install --no-immutable
 
       - name: Update npm CLI for trusted publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Problem

The **Publish Release** workflow fails at its very first step (`Setup Node + Yarn` → `yarn install --immutable`) on `release/2.14.x`:

```
The lockfile would have been modified by this install, which is explicitly forbidden.
```

`release/2.14.x` is consistent at the package.json level (libs **and** apps all at `2.14.0`), but `yarn.lock` still carries a disconnected, self-referential cluster of stale `@enclave-vm/*@npm:2.13.0` entries (PR #65 did not actually prune them). A clean install prunes that cluster; immutable mode forbids it, so the job dies before any version-bump / lock-sync step runs.

This is structural: `release/*` is a **long-lived, auto-incrementing** branch. Its committed lockfile legitimately lags the bumped versions, and the publish job rewrites the lock every run — so an immutable check at setup is the wrong guard there.

## Fix

- `Setup Node + Yarn` → `install: "false"` (skip the immutable install)
- New `Install dependencies` step → `yarn install --no-immutable`

The publish job is the source of truth for versions, so it now self-heals lockfile drift instead of deadlocking. The next run prunes the stale entries, computes the next patch (`2.14.1`, since `v2.14.0` is already published/tagged), bumps, syncs the lock, and commits a clean lockfile. Immutable installs still guard normal PR/push CI.

Pairs with the already-merged post-bump `Sync lockfile to bumped versions` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow's dependency installation to prevent lockfile and version drift issues on long-lived release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->