### PR TITLE
feat: enhance security by preventing raw host object leaks in proxy and enclave

### DIFF
--- a/docs/enclave/core-libraries/enclave-browser/security-architecture.mdx
+++ b/docs/enclave/core-libraries/enclave-browser/security-architecture.mdx
@@ -136,6 +136,12 @@ Every global object exposed to user code is wrapped in a `Proxy` that blocks acc
 
 The proxy behavior is configurable per security level. At `STRICT` and `SECURE` levels, accessing blocked properties throws an error. At `PERMISSIVE`, it returns `undefined`.
 
+#### Pinned properties
+
+A JavaScript `get` trap must report the exact value of a non-configurable, non-writable own data property, so the proxy can neither wrap nor hide one. Primitives in that position are reported as-is — this covers constants such as `Math.PI` and hardened slots pinned to `undefined`. An **object or function** in that position is refused with a `SecurityError` regardless of `throwOnBlocked`, because returning the reference would put an unwrapped object graph in reach of sandboxed code, and that graph's prototype chain leads to a `Function` constructor.
+
+This matters for host values that pin object-valued internals: a Zod schema pins `_zod` this way, and every class pins `prototype`. Hand sandboxed code plain serialized data rather than live host objects — a structurally cloned or JSON-projected value has no pinned members and reads normally.
+
 Additionally, dangerous static methods on `Object` are neutralized: `defineProperty`, `defineProperties`, `setPrototypeOf`, `getOwnPropertyDescriptor`, and `getOwnPropertyDescriptors`.
 
 ### Layer 7: Safe Runtime Wrappers

--- a/docs/enclave/core-libraries/enclave-browser/security-architecture.mdx
+++ b/docs/enclave/core-libraries/enclave-browser/security-architecture.mdx
@@ -136,11 +136,7 @@ Every global object exposed to user code is wrapped in a `Proxy` that blocks acc
 
 The proxy behavior is configurable per security level. At `STRICT` and `SECURE` levels, accessing blocked properties throws an error. At `PERMISSIVE`, it returns `undefined`.
 
-#### Pinned properties
-
-A JavaScript `get` trap must report the exact value of a non-configurable, non-writable own data property, so the proxy can neither wrap nor hide one. Primitives in that position are reported as-is — this covers constants such as `Math.PI` and hardened slots pinned to `undefined`. An **object or function** in that position is refused with a `SecurityError` regardless of `throwOnBlocked`, because returning the reference would put an unwrapped object graph in reach of sandboxed code, and that graph's prototype chain leads to a `Function` constructor.
-
-This matters for host values that pin object-valued internals: a Zod schema pins `_zod` this way, and every class pins `prototype`. Hand sandboxed code plain serialized data rather than live host objects — a structurally cloned or JSON-projected value has no pinned members and reads normally.
+Custom `globals` are serialized into the inner frame's bootstrap, so sandboxed code only ever sees plain data for them — no live outer-page object crosses the frame boundary.
 
 Additionally, dangerous static methods on `Object` are neutralized: `defineProperty`, `defineProperties`, `setPrototypeOf`, `getOwnPropertyDescriptor`, and `getOwnPropertyDescriptors`.
 

--- a/docs/enclave/core-libraries/enclave-vm/double-vm.mdx
+++ b/docs/enclave/core-libraries/enclave-vm/double-vm.mdx
@@ -197,6 +197,18 @@ When the rate limit is exceeded, subsequent calls are blocked until the rate dro
 4. **Audit Trail** - Operation history for forensics
 5. **Defense in Depth** - Additional layer beyond AST validation
 
+## Host Value Boundary
+
+Custom `globals`, and everything reachable from what they return, are wrapped in a membrane that blocks `constructor`, `prototype`, and `__proto__`. One descriptor shape cannot be wrapped: a JavaScript `get` trap is required to report the exact value of a non-configurable, non-writable own data property, so such a property can be neither wrapped nor hidden.
+
+For host-owned values the membrane therefore refuses that read with a `SecurityError` whenever the pinned value is an object or a function — returning the reference would place an unwrapped host object graph within reach of sandboxed code, and that graph's prototype chain leads to the host `Function` constructor. Pinned **primitives** are still reported as-is, so numeric constants and slots pinned to `undefined` read normally.
+
+Values owned by the sandbox's own realms keep the exact-value behavior. Their intrinsics run with code generation from strings disabled, and `new Array()` and `instanceof` both depend on reading a pinned `prototype`.
+
+The practical consequence for embedders: sandboxed code should receive only plain serialized data, never live host objects. A structurally cloned or JSON-projected value has no pinned members and reads normally, whereas a Zod schema pins `_zod` and every class pins `prototype`.
+
+The exported `createSecureProxy()` helper applies the same rule and always treats its target as host-owned.
+
 ## Performance Considerations
 
 The Double VM adds minimal overhead:

--- a/libs/core/src/__tests__/enclave.host-reference-leak.spec.ts
+++ b/libs/core/src/__tests__/enclave.host-reference-leak.spec.ts
@@ -27,6 +27,17 @@
  *    trap re-wraps every call result behind the security barrier (at a fresh depth so chained
  *    calls cannot inflate past the recursion cap).
  *
+ * 3. Custom-global results leaked a raw host object through a pinned property
+ *    A JavaScript `get` trap MUST report the exact value of a non-configurable, non-writable
+ *    data property, so the membrane cannot wrap it. It used to hand the raw reference back,
+ *    which meant any host object carrying such a property (a Zod v4 schema pins `_zod` this
+ *    way) delivered an unwrapped host object graph to sandbox code, and from there
+ *    `.constructor` reaches the host `Function` constructor. Fix: values owned by the HOST
+ *    realm are wrapped in host mode, where an object/function in that position is refused
+ *    (throwing satisfies the invariant that wrapping would break). Primitives are still
+ *    reported, and realm-owned intrinsics keep their previous behaviour so `new Array()`,
+ *    `instanceof`, and prototype-based memory patching continue to work.
+ *
  * @packageDocumentation
  */
 
@@ -248,6 +259,150 @@ describe('GHSA-grmc-r8vw-226r: callTool().then() host Promise leak', () => {
     const result = await enclave.run(code);
     expect(result.success).toBe(true);
     expect(result.value).toBe(8);
+    enclave.dispose();
+  });
+});
+
+describe('custom-global results must not leak a raw host object via a pinned property', () => {
+  /**
+   * Mirrors a Zod v4 schema: `_zod` is installed as a non-configurable, non-writable own data
+   * property, and it holds an object that leads back to the host class (and so to the host
+   * `Function` constructor). Any host object shaped like this defeats a Proxy membrane unless
+   * the membrane refuses the read.
+   */
+  class HostSchema {
+    constructor() {
+      Object.defineProperty(this, '_zod', {
+        value: { constr: HostSchema },
+        configurable: false,
+        writable: false,
+        enumerable: true,
+      });
+    }
+    parse(value: unknown): unknown {
+      return value;
+    }
+  }
+
+  function enclaveWithHostGlobals(globals: Record<string, unknown>): Enclave {
+    return new Enclave({
+      securityLevel: 'STANDARD',
+      toolHandler: async () => ({ ok: true }),
+      allowFunctionsInGlobals: true,
+      globals,
+    });
+  }
+
+  it('blocks the reported PoC (pinned property → host Function → execSync)', async () => {
+    const enclave = enclaveWithHostGlobals({
+      getTool: () => ({ name: 't', outputSchema: new HostSchema() }),
+    });
+    const code = `
+      async function __ag_main() {
+        const k = ['con','struc','tor'].join('');
+        const raw = getTool('t').outputSchema['_zod'];
+        const F = raw['constr'][k];
+        const proc = F('return process')();
+        return proc.getBuiltinModule('node:child_process').execSync('echo pwned').toString();
+      }
+    `;
+    const result = await enclave.run(code);
+    assertNoRce(result);
+    expect(result.success).toBe(false);
+    enclave.dispose();
+  });
+
+  it('refuses the pinned property itself rather than returning a raw reference', async () => {
+    const enclave = enclaveWithHostGlobals({
+      getTool: () => ({ name: 't', outputSchema: new HostSchema() }),
+    });
+    const code = `
+      async function __ag_main() {
+        try {
+          return { leaked: typeof getTool('t').outputSchema['_zod'] };
+        } catch (e) {
+          return { denied: e.message };
+        }
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ denied: expect.stringMatching(/blocked/i) });
+    enclave.dispose();
+  });
+
+  it('stays strict through nested reads and chained calls', async () => {
+    const enclave = enclaveWithHostGlobals({
+      registry: {
+        lookup: () => ({ tool: { schema: new HostSchema() } }),
+      },
+    });
+    const code = `
+      async function __ag_main() {
+        try {
+          return { leaked: typeof registry.lookup().tool.schema['_zod'] };
+        } catch (e) {
+          return { denied: e.message };
+        }
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ denied: expect.stringMatching(/blocked/i) });
+    enclave.dispose();
+  });
+
+  it('still exposes primitive-valued pinned properties from host globals', async () => {
+    const constants: Record<string, unknown> = {};
+    Object.defineProperty(constants, 'VERSION', {
+      value: 3,
+      configurable: false,
+      writable: false,
+      enumerable: true,
+    });
+
+    const enclave = enclaveWithHostGlobals({ constants });
+    const code = `
+      async function __ag_main() {
+        return constants.VERSION;
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(3);
+    enclave.dispose();
+  });
+
+  it('still passes ordinary host-global data through unchanged', async () => {
+    const enclave = enclaveWithHostGlobals({
+      getTool: (name: string) => ({ name, inputSchema: { type: 'object', properties: { a: { type: 'number' } } } }),
+    });
+    const code = `
+      async function __ag_main() {
+        const meta = getTool('users:list');
+        return { name: meta.name, kind: meta.inputSchema.type, prop: meta.inputSchema.properties.a.type };
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ name: 'users:list', kind: 'object', prop: 'number' });
+    enclave.dispose();
+  });
+
+  it('leaves realm-owned intrinsics usable (host mode must not touch them)', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        return {
+          joined: new Array(3).fill('x').join('-'),
+          repeated: 'ab'.repeat(2),
+          parsed: JSON.parse('{"n":1}').n,
+        };
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ joined: 'x-x-x', repeated: 'abab', parsed: 1 });
     enclave.dispose();
   });
 });

--- a/libs/core/src/__tests__/enclave.host-reference-leak.spec.ts
+++ b/libs/core/src/__tests__/enclave.host-reference-leak.spec.ts
@@ -284,13 +284,25 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     }
   }
 
+  // Disposal must happen even when an assertion throws, otherwise a failing test leaves its
+  // worker pool alive and jest hangs on the surviving handles.
+  const created: Enclave[] = [];
+
+  afterEach(() => {
+    while (created.length > 0) {
+      created.pop()?.dispose();
+    }
+  });
+
   function enclaveWithHostGlobals(globals: Record<string, unknown>): Enclave {
-    return new Enclave({
+    const enclave = new Enclave({
       securityLevel: 'STANDARD',
       toolHandler: async () => ({ ok: true }),
       allowFunctionsInGlobals: true,
       globals,
     });
+    created.push(enclave);
+    return enclave;
   }
 
   it('blocks the reported PoC (pinned property → host Function → execSync)', async () => {
@@ -308,8 +320,9 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     `;
     const result = await enclave.run(code);
     assertNoRce(result);
+    // The run must fail at the membrane, not somewhere incidental further down the chain.
     expect(result.success).toBe(false);
-    enclave.dispose();
+    expect(result.error?.message).toMatch(/Access to '_zod' is blocked/);
   });
 
   it('refuses the pinned property itself rather than returning a raw reference', async () => {
@@ -328,7 +341,6 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     const result = await enclave.run(code);
     expect(result.success).toBe(true);
     expect(result.value).toEqual({ denied: expect.stringMatching(/blocked/i) });
-    enclave.dispose();
   });
 
   it('stays strict through nested reads and chained calls', async () => {
@@ -349,7 +361,6 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     const result = await enclave.run(code);
     expect(result.success).toBe(true);
     expect(result.value).toEqual({ denied: expect.stringMatching(/blocked/i) });
-    enclave.dispose();
   });
 
   it('still exposes primitive-valued pinned properties from host globals', async () => {
@@ -370,7 +381,6 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     const result = await enclave.run(code);
     expect(result.success).toBe(true);
     expect(result.value).toBe(3);
-    enclave.dispose();
   });
 
   it('still passes ordinary host-global data through unchanged', async () => {
@@ -386,11 +396,10 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     const result = await enclave.run(code);
     expect(result.success).toBe(true);
     expect(result.value).toEqual({ name: 'users:list', kind: 'object', prop: 'number' });
-    enclave.dispose();
   });
 
   it('leaves realm-owned intrinsics usable (host mode must not touch them)', async () => {
-    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const enclave = enclaveWithHostGlobals({});
     const code = `
       async function __ag_main() {
         return {
@@ -403,6 +412,5 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     const result = await enclave.run(code);
     expect(result.success).toBe(true);
     expect(result.value).toEqual({ joined: 'x-x-x', repeated: 'abab', parsed: 1 });
-    enclave.dispose();
   });
 });

--- a/libs/core/src/__tests__/secure-proxy.spec.ts
+++ b/libs/core/src/__tests__/secure-proxy.spec.ts
@@ -392,6 +392,51 @@ describe('SecureProxy', () => {
       expect((proxy as any).frozen).toBe(42);
     });
 
+    it('should refuse an object-valued non-configurable non-writable property', () => {
+      // The proxy invariant forbids wrapping such a value, and handing back the raw
+      // reference would put an unwrapped host object graph in reach of sandbox code.
+      // Denying the read is the only invariant-safe outcome.
+      const escapeHatch = { reachable: function inner() {} };
+      const obj = {};
+      Object.defineProperty(obj, 'pinned', {
+        value: escapeHatch,
+        configurable: false,
+        writable: false,
+        enumerable: true,
+      });
+
+      const proxy = createSecureProxy(obj);
+
+      expect(() => (proxy as any).pinned).toThrow(/blocked/i);
+    });
+
+    it('should not leak a frozen class prototype through the blocked-property path', () => {
+      class Widget {
+        value = 1;
+      }
+      Object.freeze(Widget.prototype);
+      const proxy = createSecureProxy(Widget) as unknown as Record<string, unknown>;
+
+      // `prototype` on a class is non-configurable and non-writable, so the old invariant
+      // concession returned it raw — from there `.constructor.constructor` is host Function.
+      expect(() => proxy['prototype']).toThrow(/blocked/i);
+    });
+
+    it('should still report primitive-valued pinned properties (no regression)', () => {
+      const proxy = createSecureProxy(Math);
+
+      expect(proxy.PI).toBe(Math.PI);
+    });
+
+    it('should still allow construction through a wrapped constructor', () => {
+      class Widget {
+        value = 7;
+      }
+      const WrappedWidget = createSecureProxy(Widget) as typeof Widget;
+
+      expect(new WrappedWidget().value).toBe(7);
+    });
+
     it('should block constructor via bound functions', () => {
       const arr = [1, 2, 3];
       const proxy = createSecureProxy(arr);

--- a/libs/core/src/__tests__/secure-proxy.spec.ts
+++ b/libs/core/src/__tests__/secure-proxy.spec.ts
@@ -410,15 +410,15 @@ describe('SecureProxy', () => {
       expect(() => (proxy as any).pinned).toThrow(/blocked/i);
     });
 
-    it('should not leak a frozen class prototype through the blocked-property path', () => {
+    it('should refuse a class prototype, which is pinned by the language', () => {
       class Widget {
         value = 1;
       }
-      Object.freeze(Widget.prototype);
       const proxy = createSecureProxy(Widget) as unknown as Record<string, unknown>;
 
-      // `prototype` on a class is non-configurable and non-writable, so the old invariant
-      // concession returned it raw — from there `.constructor.constructor` is host Function.
+      // `prototype` on a class is already non-configurable and non-writable, so this read is
+      // decided by the invariant branch rather than the blocked-property list. The old
+      // concession returned it raw, and `.constructor.constructor` from there is host Function.
       expect(() => proxy['prototype']).toThrow(/blocked/i);
     });
 

--- a/libs/core/src/double-vm/parent-vm-bootstrap.ts
+++ b/libs/core/src/double-vm/parent-vm-bootstrap.ts
@@ -832,8 +832,10 @@ ${stackTraceHardeningCode}
   // Reference ID pattern for detecting sidecar references
   const refIdPattern = /^__REF_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}__$/i;
 
-  // Proxy cache to avoid infinite recursion and duplicate wrapping
+  // Proxy caches to avoid infinite recursion and duplicate wrapping. Host-owned values are
+  // cached separately from realm-owned ones because the two use different blocking rules.
   const proxyCache = new WeakMap();
+  const hostProxyCache = new WeakMap();
 
   /**
    * Create a secure proxy that blocks access to dangerous properties
@@ -842,9 +844,15 @@ ${stackTraceHardeningCode}
    * IMPORTANT: Must respect JavaScript proxy invariants:
    * - Non-configurable properties must return their actual value
    * - Non-configurable non-writable properties cannot be hidden
+   *
+   * The host flag marks a value that originates in the HOST realm (custom globals and
+   * everything reachable from what they return). The host realm is the only one with code
+   * generation from strings enabled, so a raw reference that escapes from it is remote code
+   * execution; such a subtree refuses the reads a realm-owned object is allowed to answer.
    */
-  function createSecureProxy(obj, depth) {
+  function createSecureProxy(obj, depth, host) {
     if (depth === undefined) depth = 0;
+    host = host === true;
     if (depth > 10) return obj; // Max depth to prevent infinite recursion
 
     // Skip primitives and null
@@ -853,8 +861,9 @@ ${stackTraceHardeningCode}
     }
 
     // Check cache
-    if (proxyCache.has(obj)) {
-      return proxyCache.get(obj);
+    var cache = host ? hostProxyCache : proxyCache;
+    if (cache.has(obj)) {
+      return cache.get(obj);
     }
 
     var proxy = new Proxy(obj, {
@@ -869,14 +878,27 @@ ${stackTraceHardeningCode}
         // the proxy must return the exact same value (cannot wrap/bind/proxy it).
         // This matters for hardened properties like Error.prepareStackTrace.
         if (descriptor && isNonConfigurable && 'value' in descriptor && descriptor.writable === false) {
-          return descriptor.value;
+          var exactValue = descriptor.value;
+          // On a host-owned value the exact reference cannot be handed over: it would cross
+          // the barrier unwrapped and its prototype chain reaches the host Function
+          // constructor. Primitives stay safe to report, so only object/function values are
+          // refused, and throwing satisfies the invariant that wrapping would break.
+          if (host && exactValue !== null && (typeof exactValue === 'object' || typeof exactValue === 'function')) {
+            throw createSafeError(
+              "Security violation: Access to '" + propName + "' is blocked. " +
+              "This property cannot be exposed without breaking the sandbox barrier."
+            );
+          }
+          return exactValue;
         }
 
         // Block dangerous properties - but respect proxy invariants
         if (blockedPropertiesSet.has(propName)) {
           // For non-configurable properties, we MUST return the actual value
-          // (JavaScript proxy invariant - can't hide non-configurable properties)
-          if (isNonConfigurable) {
+          // (JavaScript proxy invariant - can't hide non-configurable properties).
+          // Host-owned values instead deny the read: every descriptor shape that could force
+          // the trap's result was handled above, so returning undefined is invariant-safe.
+          if (isNonConfigurable && !host) {
             return Reflect.get(target, property, receiver);
           }
           if (throwOnBlocked) {
@@ -894,13 +916,13 @@ ${stackTraceHardeningCode}
         // Then recursively proxy the bound function to block constructor access
         if (typeof value === 'function') {
           var boundMethod = value.bind(target);
-          return createSecureProxy(boundMethod, depth + 1);
+          return createSecureProxy(boundMethod, depth + 1, host);
         }
 
         // Recursively proxy nested objects to maintain security barrier
         // This prevents attacks like: process.env.__proto__.constructor
         if (value !== null && typeof value === 'object') {
-          return createSecureProxy(value, depth + 1);
+          return createSecureProxy(value, depth + 1, host);
         }
 
         return value;
@@ -982,7 +1004,7 @@ ${stackTraceHardeningCode}
       // Results are re-wrapped at a FRESH depth (0) so a chain of calls such as
       // then().then() cannot inflate depth past the recursion cap and leak an unwrapped value.
       apply: function(target, thisArg, args) {
-        return createSecureProxy(Reflect.apply(target, thisArg, args), 0);
+        return createSecureProxy(Reflect.apply(target, thisArg, args), 0, host);
       }
       // NOTE: intentionally NO construct trap here (unlike the standalone secure-proxy used
       // for single-VM mode). Every constructor reachable from sandbox code resolves to an
@@ -995,11 +1017,11 @@ ${stackTraceHardeningCode}
       // a non-extensible target), masking legitimate errors.
     });
 
-    proxyCache.set(obj, proxy);
+    cache.set(obj, proxy);
     // Idempotency: re-wrapping an already-secure proxy must return it unchanged, so an apply
     // result that is itself already a secure proxy is not double-wrapped (which would nest
     // proxies and inflate depth toward the recursion cap).
-    proxyCache.set(proxy, proxy);
+    cache.set(proxy, proxy);
     return proxy;
   }
 
@@ -1934,10 +1956,13 @@ ${stackTraceHardeningCode}
   // Add user-provided globals if any (also wrapped with secure proxy and non-writable)
   // SECURITY: Use enumerable: false to prevent Object.assign({}, this) from copying globals
   // This blocks Vector 380 (Bridge-Serialized State Reflection) attack
+  // Custom globals are HOST-realm values, so they are wrapped in host mode: the whole
+  // subtree reachable through them (including whatever their calls return) refuses to hand
+  // back a raw reference, even for descriptor shapes where a realm-owned object may.
   if (hostConfig.globals) {
     for (var uKey in hostConfig.globals) {
       if (hostConfig.globals.hasOwnProperty(uKey)) {
-        var wrappedGlobal = createSecureProxy(hostConfig.globals[uKey]);
+        var wrappedGlobal = createSecureProxy(hostConfig.globals[uKey], 0, true);
         Object.defineProperty(innerContext, uKey, {
           value: wrappedGlobal,
           writable: false,

--- a/libs/core/src/secure-proxy.ts
+++ b/libs/core/src/secure-proxy.ts
@@ -490,25 +490,32 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
         // Convert symbol to string for checking
         const propName = typeof property === 'symbol' ? property.toString() : property;
 
-        // Check if property is non-configurable (proxy invariant requires returning actual value)
+        // A non-configurable, non-writable data property must be reported with its exact
+        // value (proxy invariant), so it can neither be wrapped nor hidden. Primitives are
+        // inert and safe to hand back — this covers constants such as Math.PI and hardened
+        // slots pinned to undefined. An object or function cannot be handed back: it would
+        // cross the barrier unwrapped and its prototype chain reaches the host Function
+        // constructor, so deny the read instead. Throwing always satisfies the invariant.
         const descriptor = Object.getOwnPropertyDescriptor(target, property);
-        const isNonConfigurable = descriptor && !descriptor.configurable;
+        if (descriptor && !descriptor.configurable && descriptor.writable === false && 'value' in descriptor) {
+          const exactValue: unknown = descriptor.value;
+          if (exactValue !== null && (typeof exactValue === 'object' || typeof exactValue === 'function')) {
+            throw createSafeError(
+              `Security violation: Access to '${String(propName)}' is blocked. ` +
+                `This property cannot be exposed without breaking the sandbox barrier.`,
+              'SecurityError',
+            );
+          }
+          return exactValue;
+        }
 
-        // Block dangerous properties (but respect proxy invariants)
+        // Block dangerous properties. Every descriptor shape that would force the trap's
+        // return value has been handled above, so denying here is invariant-safe.
         if (typeof propName === 'string' && blockedSet.has(propName)) {
           if (options.onBlocked) {
             options.onBlocked(target, propName);
           }
 
-          // For non-configurable, non-writable properties, JavaScript proxy invariants require
-          // returning the EXACT same object reference. We cannot proxy the return value.
-          // This is a fundamental JS limitation for built-in properties like Array.prototype.
-          if (isNonConfigurable && descriptor && !descriptor.writable) {
-            // Must return exact value to satisfy invariant
-            return Reflect.get(target, property, receiver);
-          }
-
-          // For configurable properties, throw or return undefined
           if (throwOnBlocked) {
             throw createSafeError(
               `Security violation: Access to '${propName}' is blocked. ` +
@@ -523,11 +530,6 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
         if (typeof target === 'function' && typeof propName === 'string' && FUNCTION_BLOCKED_PROPERTIES.has(propName)) {
           if (options.onBlocked) {
             options.onBlocked(target, propName);
-          }
-
-          // Same invariant handling for non-configurable, non-writable properties
-          if (isNonConfigurable && descriptor && !descriptor.writable) {
-            return Reflect.get(target, property, receiver);
           }
 
           if (throwOnBlocked) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Hardened secure proxy behavior for non-configurable, non-writable pinned properties: object/function pinned values are blocked with a `SecurityError`, while primitive pinned values still work.
  - Strengthened host-value boundary handling for custom globals to prevent exposing host object graphs through nested and chained access.
  - Kept sandbox realm intrinsics and constructor behavior working as expected.
- **Tests**
  - Added regression coverage for sandbox escape attempts and proxy invariant attack scenarios involving pinned properties.
- **Documentation**
  - Clarified how globals are safely serialized/wrapped and added a “Host Value Boundary” explanation for pinned values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->