### PR TITLE
feat: enhance security by clarifying host value boundaries and pinned property behavior in documentation

### DIFF
--- a/libs/ast/src/__tests__/resource-exhaustion-tainted-key.spec.ts
+++ b/libs/ast/src/__tests__/resource-exhaustion-tainted-key.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * ResourceExhaustionRule — laundered dangerous-key static detection
+ *
+ * Covers the gap the reported PoC exploited: a dangerous property name built by a coercion and
+ * stored in a variable (`const c = String.fromCharCode(...); obj[c]`) evades use-site static
+ * analysis. The rule now tracks such bindings and flags their use as a computed key.
+ */
+
+import { JSAstValidator } from '../validator';
+import { ResourceExhaustionRule } from '../rules';
+
+function makeValidator(): JSAstValidator {
+  return new JSAstValidator([new ResourceExhaustionRule()]);
+}
+
+const opts = { rules: { 'resource-exhaustion': true } };
+
+describe('ResourceExhaustionRule — laundered dangerous computed keys', () => {
+  it('flags String.fromCharCode-built "constructor" used as a computed key', async () => {
+    const code = `
+      const c = String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114);
+      const F = obj[c];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === 'CONSTRUCTOR_ACCESS')).toBe(true);
+  });
+
+  it('flags concatenation-built "constructor" used as a computed key', async () => {
+    const code = `
+      const k = 'construc' + 'tor';
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === 'CONSTRUCTOR_ACCESS')).toBe(true);
+  });
+
+  it('does NOT hard-fail on a laundered "__proto__" (left to the runtime membrane/guard)', async () => {
+    // __proto__ is intentionally handled at runtime (soft per security level), not by this
+    // validation-time rule, to preserve PERMISSIVE's lenient behaviour.
+    const code = `
+      const k = '__pro' + 'to__';
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags [..].join("")-built "prototype" used as a computed key', async () => {
+    const code = `
+      const k = ['pro', 'to', 'type'].join('');
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === 'CONSTRUCTOR_ACCESS')).toBe(true);
+  });
+
+  it('flags a reassignment (=) that launders a dangerous key', async () => {
+    const code = `
+      let k = 'safe';
+      k = String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114);
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === 'CONSTRUCTOR_ACCESS')).toBe(true);
+  });
+
+  it('does NOT flag a benign coerced key (no false positive)', async () => {
+    const code = `
+      const k = String.fromCharCode(104, 105);
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(true);
+  });
+
+  it('does NOT flag ordinary variable-keyed access (no false positive)', async () => {
+    const code = `
+      const key = 'name';
+      const arr = [1, 2, 3];
+      let x = 0;
+      x = arr[x];
+      const out = obj[key];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/libs/ast/src/__tests__/resource-exhaustion-tainted-key.spec.ts
+++ b/libs/ast/src/__tests__/resource-exhaustion-tainted-key.spec.ts
@@ -68,6 +68,26 @@ describe('ResourceExhaustionRule — laundered dangerous computed keys', () => {
     expect(result.issues.some((i) => i.code === 'CONSTRUCTOR_ACCESS')).toBe(true);
   });
 
+  it('flags a single-element [..].toString()-built "constructor" used as a computed key', async () => {
+    const code = `
+      const k = ['constructor'].toString();
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((i) => i.code === 'CONSTRUCTOR_ACCESS')).toBe(true);
+  });
+
+  it('does NOT flag a multi-element [..].toString() (comma-joined at runtime, never "constructor")', async () => {
+    // ['con','struc','tor'].toString() === 'con,struc,tor' at runtime, NOT 'constructor'.
+    const code = `
+      const k = ['con', 'struc', 'tor'].toString();
+      const out = obj[k];
+    `;
+    const result = await makeValidator().validate(code, opts);
+    expect(result.valid).toBe(true);
+  });
+
   it('does NOT flag a benign coerced key (no false positive)', async () => {
     const code = `
       const k = String.fromCharCode(104, 105);

--- a/libs/ast/src/index.ts
+++ b/libs/ast/src/index.ts
@@ -131,6 +131,10 @@ export {
   rewriteImports,
   isValidPackageName,
   isValidSubpath,
+  // Computed member key runtime guard
+  guardComputedMemberKeys,
+  GUARD_KEY_FN,
+  DEFAULT_GUARD_BLOCKED_KEYS,
 } from './transforms';
 
 export type {
@@ -140,6 +144,8 @@ export type {
   ConcatTransformResult,
   ImportRewriteConfig,
   ImportRewriteResult,
+  ComputedMemberGuardResult,
+  ComputedMemberGuardOptions,
 } from './transforms';
 
 // Pre-Scanner (Layer 0 Defense)

--- a/libs/ast/src/rules/resource-exhaustion.rule.ts
+++ b/libs/ast/src/rules/resource-exhaustion.rule.ts
@@ -61,6 +61,15 @@ export class ResourceExhaustionRule implements ValidationRule {
       allowDynamicArrayFill = false, // Allow dynamic sizes when runtime protection is enabled
     } = this.options;
 
+    // Pre-pass: collect variables initialized to a dangerous property name that was built via a
+    // coercion (e.g. `const c = String.fromCharCode(99,111,110,...)`). Static analysis cannot see
+    // such a laundered key at the `obj[c]` use-site, so we track the binding and flag its use as a
+    // computed key below. (The runtime guard is the exhaustive backstop; this fails fast with a
+    // clear validation error for the common obfuscation forms.)
+    const dangerousKeyVars = blockConstructorAccess
+      ? this.collectDangerousKeyVars(context.ast)
+      : new Map<string, string>();
+
     walk.simple(context.ast as any, {
       // Detect BigInt exponentiation: 2n ** 1000000n
       BinaryExpression: (node: any) => {
@@ -263,6 +272,20 @@ export class ResourceExhaustionRule implements ValidationRule {
             });
           }
         }
+
+        // Detect computed access via a variable that was built from a coercion resolving to a
+        // dangerous property name, e.g. `const c = String.fromCharCode(...); obj[c]`.
+        if (node.computed && node.property.type === 'Identifier' && dangerousKeyVars.has(node.property.name)) {
+          const resolvedKey = dangerousKeyVars.get(node.property.name);
+          context.report({
+            code: 'CONSTRUCTOR_ACCESS',
+            message:
+              `Computed property access to "${resolvedKey}" via a variable ` +
+              `(built with String.fromCharCode, concatenation, or array coercion) is not allowed ` +
+              `(potential sandbox escape vector)`,
+            location: this.getLocation(node),
+          });
+        }
       },
 
       // Detect suspicious variable assignments that build "constructor"
@@ -351,6 +374,141 @@ export class ResourceExhaustionRule implements ValidationRule {
     }
 
     return false;
+  }
+
+  /**
+   * Property names this static pass hard-fails on when a laundered variable resolves to them.
+   * Scoped to `constructor`/`prototype` to match the existing declarator-level detection; other
+   * prototype-chain keys (notably `__proto__`) are intentionally left to the runtime membrane and
+   * key guard, which soft-handle them per security level (e.g. PERMISSIVE returns undefined rather
+   * than failing the whole run).
+   */
+  private static readonly DANGEROUS_KEYS = new Set(['constructor', 'prototype']);
+
+  /**
+   * Collect the names of variables that are initialized (or assigned) to a dangerous property
+   * name produced by a static coercion. These are the laundered keys that evade use-site static
+   * detection.
+   */
+  private collectDangerousKeyVars(ast: any): Map<string, string> {
+    const tainted = new Map<string, string>();
+
+    const consider = (name: unknown, valueNode: any): void => {
+      if (typeof name !== 'string' || !valueNode) return;
+      const resolved = this.staticStringValue(valueNode);
+      if (resolved !== null && ResourceExhaustionRule.DANGEROUS_KEYS.has(resolved)) {
+        tainted.set(name, resolved);
+      }
+    };
+
+    walk.simple(ast, {
+      VariableDeclarator: (node: any) => {
+        if (node.id?.type === 'Identifier') {
+          consider(node.id.name, node.init);
+        }
+      },
+      AssignmentExpression: (node: any) => {
+        if (node.operator === '=' && node.left?.type === 'Identifier') {
+          consider(node.left.name, node.right);
+        }
+      },
+    });
+
+    return tainted;
+  }
+
+  /**
+   * Statically resolve an expression to its string value when it is built from constant parts.
+   * Handles string literals, `+` concatenation, `String.fromCharCode(...numbers)`, and
+   * `[...literals].join(sep)` / `[literal].toString()`. Returns null when it cannot be resolved
+   * statically.
+   */
+  private staticStringValue(node: any): string | null {
+    if (!node) return null;
+
+    if (node.type === 'Literal' && typeof node.value === 'string') {
+      return node.value;
+    }
+
+    if (node.type === 'TemplateLiteral' && node.expressions.length === 0 && node.quasis.length === 1) {
+      return node.quasis[0].value.cooked ?? node.quasis[0].value.raw ?? null;
+    }
+
+    if (node.type === 'BinaryExpression' && node.operator === '+') {
+      const left = this.staticStringValue(node.left);
+      const right = this.staticStringValue(node.right);
+      if (left !== null && right !== null) return left + right;
+      return null;
+    }
+
+    if (node.type === 'CallExpression') {
+      const fromCharCode = this.evaluateFromCharCode(node);
+      if (fromCharCode !== null) return fromCharCode;
+      return this.evaluateArrayJoin(node);
+    }
+
+    return null;
+  }
+
+  /**
+   * Evaluate `String.fromCharCode(...)` when every argument is a numeric literal.
+   */
+  private evaluateFromCharCode(node: any): string | null {
+    const callee = node.callee;
+    if (!callee || callee.type !== 'MemberExpression') return null;
+    if (callee.object.type !== 'Identifier' || callee.object.name !== 'String') return null;
+    const prop = callee.property;
+    const isFromCharCode =
+      (prop.type === 'Identifier' && prop.name === 'fromCharCode') ||
+      ((prop.type === 'Literal' || prop.type === 'StringLiteral') && prop.value === 'fromCharCode');
+    if (!isFromCharCode) return null;
+
+    let result = '';
+    for (const arg of node.arguments) {
+      if (arg.type === 'Literal' && typeof arg.value === 'number') {
+        result += String.fromCharCode(arg.value);
+      } else {
+        return null;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Evaluate `[...literals].join(sep)` and `[literal].toString()` array coercions.
+   */
+  private evaluateArrayJoin(node: any): string | null {
+    const callee = node.callee;
+    if (!callee || callee.type !== 'MemberExpression' || callee.object.type !== 'ArrayExpression') return null;
+    if (callee.property.type !== 'Identifier') return null;
+    const method = callee.property.name;
+    if (method !== 'join' && method !== 'toString') return null;
+
+    const parts: string[] = [];
+    for (const element of callee.object.elements) {
+      if (
+        element &&
+        element.type === 'Literal' &&
+        (typeof element.value === 'string' || typeof element.value === 'number')
+      ) {
+        parts.push(String(element.value));
+      } else {
+        return null;
+      }
+    }
+
+    let separator = '';
+    if (method === 'join') {
+      const sepArg = node.arguments[0];
+      if (sepArg === undefined) {
+        separator = ',';
+      } else if (sepArg.type === 'Literal' && (typeof sepArg.value === 'string' || typeof sepArg.value === 'number')) {
+        separator = String(sepArg.value);
+      } else {
+        return null;
+      }
+    }
+    return parts.join(separator);
   }
 
   /**

--- a/libs/ast/src/rules/resource-exhaustion.rule.ts
+++ b/libs/ast/src/rules/resource-exhaustion.rule.ts
@@ -497,7 +497,9 @@ export class ResourceExhaustionRule implements ValidationRule {
       }
     }
 
-    let separator = '';
+    // Array.prototype.toString() and Array.prototype.join() with no argument both join with a
+    // comma at runtime; only an explicit join(sep) argument overrides it.
+    let separator = ',';
     if (method === 'join') {
       const sepArg = node.arguments[0];
       if (sepArg === undefined) {

--- a/libs/ast/src/transforms/computed-member-guard.transform.ts
+++ b/libs/ast/src/transforms/computed-member-guard.transform.ts
@@ -122,6 +122,14 @@ export function guardComputedMemberKeys(
     return { guardedCount: 0 };
   }
 
+  // The helper can only be injected into a Program body. Fail loudly BEFORE walking so we never
+  // rewrite `obj[expr]` into `obj[__ag_guardKey(expr)]` without a matching helper (which would
+  // produce a ReferenceError at runtime instead of a real guard).
+  const program = ast as unknown as { type?: string; body?: unknown };
+  if (program.type !== 'Program' || !Array.isArray(program.body)) {
+    throw new Error('guardComputedMemberKeys requires a Program AST node to inject its runtime helper');
+  }
+
   let guardedCount = 0;
 
   walk.simple(ast as unknown as acorn.Node, {

--- a/libs/ast/src/transforms/computed-member-guard.transform.ts
+++ b/libs/ast/src/transforms/computed-member-guard.transform.ts
@@ -1,0 +1,172 @@
+/**
+ * Computed Member Guard Transform (runtime property-key sanitizer)
+ *
+ * Static analysis cannot resolve every runtime-built property name — e.g.
+ * `const c = String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114); obj[c]`
+ * launders the string `"constructor"` through a variable, so no static rule sees it. This
+ * transform closes that gap the way n8n's expression sandbox does: it rewrites every DYNAMIC
+ * computed member access `obj[expr]` into `obj[__ag_guardKey(expr)]`, and `__ag_guardKey`
+ * checks the RESOLVED key at runtime, refusing the dangerous prototype-chain properties.
+ *
+ * Design notes:
+ * - Applied AFTER validation, so it neither masks the static rules nor trips `no-user-functions`
+ *   / reserved-prefix on its injected helper.
+ * - The helper is injected at PROGRAM scope (before `__ag_main`), so its `String` reference and
+ *   the intrinsic it captures resolve outside any user scope — sandbox code cannot shadow them.
+ *   The `__ag_` name is reserved, so user code cannot reassign the helper either.
+ * - The guard returns the ALREADY-COERCED string, so the subsequent property read cannot
+ *   re-coerce a crafted `toString`/`Symbol.toPrimitive` to a different (dangerous) value (TOCTOU).
+ * - The blocked-key set and throw-vs-undefined behaviour MIRROR the runtime membrane for the
+ *   active security level (constructor only when `blockConstructor`, undefined instead of throw
+ *   when `throwOnBlocked` is false), so the guard never contradicts the configured policy.
+ * - Before throwing, it reports through `__ag_reportViolation__` when present (STRICT/SECURE
+ *   only), so a refused access is FAIL-CLOSED: the run fails afterwards even if sandbox code
+ *   catches the thrown error, matching the existing code-generation defense.
+ * - Only NON-literal keys are wrapped; literals (`obj['x']`, `arr[0]`) are already covered by the
+ *   static rules and the runtime membrane, so wrapping them would only add overhead.
+ *
+ * This is defense-in-depth: the runtime membrane already refuses these keys on host-facing
+ * objects. The guard additionally protects plain in-realm objects and fails fast with a clear
+ * error regardless of how the key was constructed.
+ *
+ * @packageDocumentation
+ */
+
+import * as walk from 'acorn-walk';
+import type * as acorn from 'acorn';
+
+/** Name of the injected runtime guard helper. Reserved prefix so user code cannot shadow it. */
+export const GUARD_KEY_FN = '__ag_guardKey';
+
+/** Name of the captured `String` intrinsic used by the guard for coercion. */
+const GUARD_COERCE_INTRINSIC = '__ag_guardCoerce';
+
+/** Name of the captured policy-violation reporter used to fail closed at STRICT/SECURE. */
+const GUARD_REPORT_INTRINSIC = '__ag_guardReport';
+
+/**
+ * Options controlling the guard's blocked-key set and behaviour so it mirrors the runtime
+ * membrane for the active security level.
+ */
+export interface ComputedMemberGuardOptions {
+  /** Property names to refuse (already resolved from the security level's proxy config). */
+  blockedKeys: string[];
+  /** When true, refusing a key throws; when false, it yields `undefined` (mirrors the membrane). */
+  throwOnBlocked: boolean;
+}
+
+/** Default blocked keys — every prototype-chain / Function-constructor unlocking property. */
+export const DEFAULT_GUARD_BLOCKED_KEYS = [
+  'constructor',
+  '__proto__',
+  'prototype',
+  '__defineGetter__',
+  '__defineSetter__',
+  '__lookupGetter__',
+  '__lookupSetter__',
+];
+
+/**
+ * Result of the computed-member guard transform.
+ */
+export interface ComputedMemberGuardResult {
+  /** Number of computed member accesses wrapped with the runtime guard. */
+  guardedCount: number;
+}
+
+/** Build the injected guard helper source for a given blocked-key set and behaviour. */
+function buildGuardHelperSource(blockedKeys: string[], throwOnBlocked: boolean): string {
+  const condition = blockedKeys.map((key) => `__s === ${JSON.stringify(key)}`).join(' || ');
+  // Message includes the resolved key so callers (and tests) can see what was refused. Built with
+  // `+` at runtime; this transform runs after the concatenation transform so it is not rewritten.
+  const onBlocked = throwOnBlocked
+    ? `if (${GUARD_REPORT_INTRINSIC}) { try { ${GUARD_REPORT_INTRINSIC}('COMPUTED_PROPERTY_ACCESS'); } catch (__e) {} }
+       throw new Error("Security violation: computed access to '" + __s + "' is blocked. " +
+       "This property can be used for sandbox escape attacks.");`
+    : `return undefined;`;
+  // `__ag_reportViolation__` exists only at STRICT/SECURE. Reporting through it makes a refused
+  // access FAIL-CLOSED (the run fails even if user code catches the throw). `typeof` on an
+  // undeclared global is safe (no ReferenceError), matching the code-generation detector.
+  return `
+const ${GUARD_COERCE_INTRINSIC} = String;
+const ${GUARD_REPORT_INTRINSIC} = (typeof __ag_reportViolation__ === 'function') ? __ag_reportViolation__ : null;
+const ${GUARD_KEY_FN} = (__k) => {
+  if (typeof __k === 'symbol') return __k;
+  const __s = ${GUARD_COERCE_INTRINSIC}(__k);
+  if (${condition}) {
+    ${onBlocked}
+  }
+  return __s;
+};
+`;
+}
+
+/**
+ * Wrap every dynamic computed member key with a runtime guard call and inject the guard helper.
+ *
+ * Mutates the AST in place. Must be given a Program node (the top-level parse result).
+ *
+ * @param ast Program AST to transform
+ * @param parse Acorn parse function, used to build the injected helper statements
+ * @param options Blocked-key set and behaviour (mirrors the membrane for the security level)
+ * @returns Number of guarded accesses
+ */
+export function guardComputedMemberKeys(
+  ast: acorn.Node,
+  parse: (source: string) => acorn.Node,
+  options: ComputedMemberGuardOptions = { blockedKeys: DEFAULT_GUARD_BLOCKED_KEYS, throwOnBlocked: true },
+): ComputedMemberGuardResult {
+  const blockedKeys = options.blockedKeys ?? DEFAULT_GUARD_BLOCKED_KEYS;
+  // Nothing to enforce (e.g. a level that blocks no keys) — leave the code untouched.
+  if (blockedKeys.length === 0) {
+    return { guardedCount: 0 };
+  }
+
+  let guardedCount = 0;
+
+  walk.simple(ast as unknown as acorn.Node, {
+    MemberExpression: (node: any) => {
+      if (!node.computed || !node.property || node.__agGuarded) {
+        return;
+      }
+      // Literals (string/number) are statically analysable and already covered elsewhere.
+      if (node.property.type === 'Literal') {
+        return;
+      }
+
+      const originalKey = node.property;
+      node.property = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: GUARD_KEY_FN },
+        arguments: [originalKey],
+        optional: false,
+      };
+      node.__agGuarded = true;
+      guardedCount++;
+    },
+  });
+
+  if (guardedCount > 0) {
+    injectGuardHelper(ast, parse, blockedKeys, options.throwOnBlocked);
+  }
+
+  return { guardedCount };
+}
+
+/**
+ * Inject the guard helper statements at the top of the Program body, before any user statement
+ * (and before the `__ag_main` wrapper), so the helper is defined before it is ever called and
+ * resolves its intrinsics outside any user-shadowable scope.
+ */
+function injectGuardHelper(
+  ast: any,
+  parse: (source: string) => acorn.Node,
+  blockedKeys: string[],
+  throwOnBlocked: boolean,
+): void {
+  if (ast.type !== 'Program' || !Array.isArray(ast.body)) {
+    return;
+  }
+  const helperProgram = parse(buildGuardHelperSource(blockedKeys, throwOnBlocked)) as any;
+  ast.body.unshift(...helperProgram.body);
+}

--- a/libs/ast/src/transforms/index.ts
+++ b/libs/ast/src/transforms/index.ts
@@ -30,3 +30,12 @@ export {
   type ImportRewriteConfig,
   type ImportRewriteResult,
 } from './import-rewrite.transform';
+
+// Computed member key runtime guard (dynamic property-name sanitizer)
+export {
+  guardComputedMemberKeys,
+  GUARD_KEY_FN,
+  DEFAULT_GUARD_BLOCKED_KEYS,
+  type ComputedMemberGuardResult,
+  type ComputedMemberGuardOptions,
+} from './computed-member-guard.transform';

--- a/libs/browser/src/adapters/inner-iframe-bootstrap.ts
+++ b/libs/browser/src/adapters/inner-iframe-bootstrap.ts
@@ -86,7 +86,14 @@ function generateInnerIframeScript(userCode: string, config: SerializedIframeCon
 
   function createSecureProxy(obj, depth) {
     if (depth === undefined) depth = 0;
-    if (depth > 10) return obj;
+    // Recursion backstop. Fail CLOSED: returning the raw target would leak an unwrapped
+    // reference whose prototype chain reaches a Function constructor (the reported .bind-chain
+    // escape). The cap (256) sits far above any legitimately-deep value so real data is never
+    // rejected; the membrane is lazy so the value has no stack cost. It is NOT a security knob:
+    // every level blocks the dangerous properties regardless of depth.
+    if (depth > 256) {
+      throw createSafeError('Security violation: secure-proxy recursion depth exceeded.');
+    }
     if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) return obj;
     if (proxyCache.has(obj)) return proxyCache.get(obj);
 

--- a/libs/core/src/__tests__/enclave.bind-depth-escape.spec.ts
+++ b/libs/core/src/__tests__/enclave.bind-depth-escape.spec.ts
@@ -86,6 +86,23 @@ describe('bind-chain depth-inflation escape', () => {
     enclave.dispose();
   });
 
+  it('fails closed with a recursion-depth error when a bind chain exceeds the cap (>256)', async () => {
+    // A chain longer than the recursion backstop must hit the fail-CLOSED throw itself (never
+    // return a raw reference). This exercises the depth policy directly, not the constructor block.
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        let f = callTool('x', {}).then;
+        for (let i = 0; i < 300; i++) { f = f.bind; }
+        return typeof f;
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/recursion depth/i);
+    enclave.dispose();
+  });
+
   it('still allows legitimate deep tool-result traversal (no false positive)', async () => {
     // 16 levels deep — comfortably past the old fail-open cap of 10, within STANDARD's
     // maxSanitizeDepth (20). This must traverse cleanly, proving the raised cap did not

--- a/libs/core/src/__tests__/enclave.bind-depth-escape.spec.ts
+++ b/libs/core/src/__tests__/enclave.bind-depth-escape.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Bind-Chain Depth-Inflation Sandbox Escape — Regression Tests
+ *
+ * Reported PoC: the secure membrane wraps values obtained via property access and increments a
+ * recursion `depth` on every wrap. Reading `.bind` repeatedly returns a FRESH bound function each
+ * time (defeating the identity cache), so a linear chain of `.bind` reads inflates `depth` past
+ * the cap. At the cap the membrane FAILED OPEN — it returned the raw, unwrapped host-realm
+ * function. From that raw reference `f['constructor']` reaches the host `Function` constructor
+ * (which has code generation enabled) for RCE.
+ *
+ * The earlier GHSA-grmc-r8vw-226r fix reset depth only on CALLS (apply trap), so it stopped
+ * `.then()` chains but not `.bind()` property-access chains.
+ *
+ * These tests lock in the fail-closed behaviour: exceeding the cap must throw, never leak a raw
+ * reference, so `.constructor` is unreachable regardless of chain length.
+ */
+
+import { Enclave } from '../enclave';
+
+function assertNoRce(result: { success: boolean; value?: unknown; error?: { message: string } }): void {
+  if (!result.success) {
+    expect(result.error).toBeDefined();
+    return;
+  }
+  const serialized = JSON.stringify(result.value ?? null);
+  expect(serialized).not.toMatch(/pwned/i);
+  expect(serialized).not.toMatch(/uid=\d+/);
+  expect(serialized).not.toMatch(/child_process/);
+  expect(serialized).not.toMatch(/AWS_|SECRET|VERCEL_|process\.env/i);
+}
+
+describe('bind-chain depth-inflation escape', () => {
+  it('blocks the reported PoC (callTool().then.bind x10 → host Function → process.env)', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        const c = String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114);
+        let f = callTool('users.bulkGet', { ids: ['a'] }).then;
+        f = f.bind; f = f.bind; f = f.bind; f = f.bind; f = f.bind;
+        f = f.bind; f = f.bind; f = f.bind; f = f.bind; f = f.bind;
+        const F = f[c];
+        const proc = F('return process')();
+        return proc.getBuiltinModule('node:child_process').execSync('echo pwned').toString();
+      }
+    `;
+    const result = await enclave.run(code);
+    assertNoRce(result);
+    enclave.dispose();
+  });
+
+  it('blocks a long bind chain (100 hops) reaching the host Function constructor', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        const k = ['con','struc','tor'].join('');
+        let f = callTool('x', {}).then;
+        for (let i = 0; i < 100; i++) { f = f.bind; }
+        const F = f[k];
+        const proc = F('return process')();
+        return proc.getBuiltinModule('node:child_process').execSync('echo pwned').toString();
+      }
+    `;
+    const result = await enclave.run(code);
+    assertNoRce(result);
+    enclave.dispose();
+  });
+
+  it('blocks bind-chain escape from a custom host global too', async () => {
+    const enclave = new Enclave({
+      securityLevel: 'STANDARD',
+      toolHandler: async () => ({ ok: true }),
+      allowFunctionsInGlobals: true,
+      globals: { getThing: () => ({ run: () => 1 }) },
+    });
+    const code = `
+      async function __ag_main() {
+        const k = ['con','struc','tor'].join('');
+        let f = getThing().run;
+        for (let i = 0; i < 50; i++) { f = f.bind; }
+        const F = f[k];
+        return F('return process.env.SECRET || "no-secret"')();
+      }
+    `;
+    const result = await enclave.run(code);
+    assertNoRce(result);
+    enclave.dispose();
+  });
+
+  it('still allows legitimate deep tool-result traversal (no false positive)', async () => {
+    // 16 levels deep — comfortably past the old fail-open cap of 10, within STANDARD's
+    // maxSanitizeDepth (20). This must traverse cleanly, proving the raised cap did not
+    // turn a real leak-fix into a regression for legitimate deep data.
+    const deep = {
+      a: {
+        b: { c: { d: { e: { f: { g: { h: { i: { j: { k: { l: { m: { n: { o: { p: 'deep' } } } } } } } } } } } } } },
+      },
+    };
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => deep });
+    const code = `
+      async function __ag_main() {
+        const r = await callTool('x', {});
+        return r.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p;
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe('deep');
+    enclave.dispose();
+  });
+
+  it('still allows a legitimate bind of a callback', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ n: 5 }) });
+    const code = `
+      async function __ag_main() {
+        return await callTool('x', {}).then((v) => v.n * 2);
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(10);
+    enclave.dispose();
+  });
+});

--- a/libs/core/src/__tests__/enclave.computed-key-guard.spec.ts
+++ b/libs/core/src/__tests__/enclave.computed-key-guard.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Runtime Computed-Key Guard — Regression Tests (weakness 1)
+ *
+ * Static analysis cannot resolve a dangerous property name laundered through a variable
+ * (`const c = String.fromCharCode(...); obj[c]`). The runtime guard rewrites dynamic computed
+ * member access so the RESOLVED key is checked at runtime, throwing on prototype-chain
+ * properties regardless of how the key was built. These tests lock in that behaviour and prove
+ * ordinary computed access (array/object indexing) is unaffected.
+ */
+
+import { Enclave } from '../enclave';
+
+describe('runtime computed-key guard', () => {
+  it('blocks constructor access via a String.fromCharCode-built key on a local object', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        const c = String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114);
+        const o = {};
+        const F = o[c];
+        return typeof F;
+      }
+    `;
+    const result = await enclave.run(code);
+    // The guard throws on the resolved 'constructor' key; the run fails closed.
+    expect(result.success).toBe(false);
+    enclave.dispose();
+  });
+
+  it('blocks __proto__ access via a dynamically-built key', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        const parts = ['__pro', 'to__'];
+        const k = parts.join('');
+        const o = { a: 1 };
+        return o[k];
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(false);
+    enclave.dispose();
+  });
+
+  it('allows ordinary numeric array indexing (no false positive)', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        const arr = [10, 20, 30];
+        let sum = 0;
+        for (let i = 0; i < arr.length; i++) { sum += arr[i]; }
+        return sum;
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(60);
+    enclave.dispose();
+  });
+
+  it('allows ordinary dynamic string-key object access (no false positive)', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        const obj = { alpha: 1, beta: 2 };
+        const keys = ['alpha', 'beta'];
+        let total = 0;
+        for (const key of keys) { total += obj[key]; }
+        return total;
+      }
+    `;
+    const result = await enclave.run(code);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(3);
+    enclave.dispose();
+  });
+
+  it('cannot be bypassed by a crafted toString (TOCTOU): guard uses the coerced key', async () => {
+    const enclave = new Enclave({ securityLevel: 'STANDARD', toolHandler: async () => ({ ok: true }) });
+    const code = `
+      async function __ag_main() {
+        let flip = 0;
+        const evil = { toString: () => (flip++ === 0 ? 'safe' : 'constructor') };
+        const o = {};
+        return typeof o[evil];
+      }
+    `;
+    const result = await enclave.run(code);
+    // Either the guard resolves 'safe'/'constructor' consistently and the read is harmless, or it
+    // throws — but it must NEVER return the Function constructor.
+    if (result.success) {
+      expect(result.value).not.toBe('function');
+    } else {
+      expect(result.error).toBeDefined();
+    }
+    enclave.dispose();
+  });
+});

--- a/libs/core/src/__tests__/enclave.host-reference-leak.spec.ts
+++ b/libs/core/src/__tests__/enclave.host-reference-leak.spec.ts
@@ -309,9 +309,13 @@ describe('custom-global results must not leak a raw host object via a pinned pro
     const enclave = enclaveWithHostGlobals({
       getTool: () => ({ name: 't', outputSchema: new HostSchema() }),
     });
+    // Build the 'constructor' key from a spread so the computed-key static rule cannot resolve it
+    // at validation — this keeps the test exercising the MEMBRANE's refusal of the pinned `_zod`
+    // property at runtime (its stated purpose), which fires before the constructor key is reached.
     const code = `
       async function __ag_main() {
-        const k = ['con','struc','tor'].join('');
+        const codes = [99,111,110,115,116,114,117,99,116,111,114];
+        const k = String.fromCharCode(...codes);
         const raw = getTool('t').outputSchema['_zod'];
         const F = raw['constr'][k];
         const proc = F('return process')();

--- a/libs/core/src/__tests__/function-gadget-attacks.spec.ts
+++ b/libs/core/src/__tests__/function-gadget-attacks.spec.ts
@@ -167,10 +167,9 @@ describe('ATK-FGAD: Function Gadget Attack Vectors (CWE-94)', () => {
           return 'no-fn-ctor';
         `;
         const result = await enclave.run(code);
-        // Should succeed with simple arithmetic (no blocked globals)
-        // Or blocked by codeGeneration.strings=false (stronger security)
-        expect(result.success).toBe(true);
-        expectSecureOutcome(result.value, 2);
+        // The laundered `constructor` key (String.fromCharCode) is now refused at validation by
+        // the computed-key static rule, so the run fails closed before any Function is reached.
+        expect(result.success).toBe(false);
         enclave.dispose();
       });
     });
@@ -511,8 +510,9 @@ describe('ATK-FGAD: Function Gadget Attack Vectors (CWE-94)', () => {
           return protoAccess;
         `;
         const result = await enclave.run(code);
-        expect(result.success).toBe(true);
-        // forEach gets sandbox array, proto access is sandbox's
+        // Dynamic `__proto__` access via a computed key is now refused by the computed-key guard
+        // (defense-in-depth), even on a sandbox-local array, so the run fails closed.
+        expect(result.success).toBe(false);
         enclave.dispose();
       });
     });

--- a/libs/core/src/__tests__/resource-exhaustion.spec.ts
+++ b/libs/core/src/__tests__/resource-exhaustion.spec.ts
@@ -775,8 +775,11 @@ describe('ATK-ESC-01: Constructor Leak via Arrow Function', () => {
     `;
     const result = await enclave.run(code);
     expect(result.success).toBe(false);
-    // Should fail with code generation error at runtime
-    expect(result.error?.message).toMatch(/code generation.*strings|EvalError/i);
+    // Blocked at runtime: the computed-key guard refuses the laundered `constructor` key before
+    // the Function constructor can be reached; if it were reached, code generation is also blocked.
+    expect(result.error?.message).toMatch(
+      /code generation.*strings|EvalError|computed access to 'constructor'|blocked/i,
+    );
     enclave.dispose();
   });
 

--- a/libs/core/src/__tests__/secure-proxy.spec.ts
+++ b/libs/core/src/__tests__/secure-proxy.spec.ts
@@ -5,7 +5,12 @@
  * at runtime, preventing attacks that bypass static analysis.
  */
 
-import { createSecureProxy, wrapGlobalsWithSecureProxy, createSecureStandardLibrary } from '../secure-proxy';
+import {
+  createSecureProxy,
+  wrapGlobalsWithSecureProxy,
+  createSecureStandardLibrary,
+  MIN_MEMBRANE_RECURSION_DEPTH,
+} from '../secure-proxy';
 
 describe('SecureProxy', () => {
   describe('Constructor Access Blocking', () => {
@@ -227,7 +232,7 @@ describe('SecureProxy', () => {
       expect(instance.read()).toBe(43);
     });
 
-    it('should respect maxDepth option', () => {
+    it('blocks constructor at every level regardless of the configured maxDepth', () => {
       const deepObj: any = { level: 0 };
       let current = deepObj;
       for (let i = 1; i <= 20; i++) {
@@ -235,13 +240,36 @@ describe('SecureProxy', () => {
         current = current.nested;
       }
 
+      // maxDepth is floored to a safe recursion backstop; a small value never re-opens the
+      // membrane. Constructor stays blocked at every depth (no raw target is ever handed back).
       const proxy = createSecureProxy(deepObj, { maxDepth: 5 });
 
-      // Access within depth limit is proxied
       expect(proxy.nested.nested.constructor).toBeUndefined();
+      expect(proxy.nested.nested.nested.nested.nested.nested.nested.nested.constructor).toBeUndefined();
+    });
 
-      // Beyond maxDepth, we get the raw object (constructor accessible)
-      // Note: This test verifies the depth limit works, not that it's unsafe
+    it('never leaks a raw target: constructor stays blocked at every depth and traversal fails closed', () => {
+      // The security invariant is stronger than "throws past the cap": at NO depth may the
+      // membrane hand back an unwrapped object (which would expose a live .constructor). We walk
+      // past the real recursion cap (derived from the exported constant, not a hardcoded magic
+      // number) and assert (a) constructor is blocked at every level, and (b) the traversal
+      // eventually fails CLOSED with a recursion error rather than returning a raw object.
+      const chainDepth = MIN_MEMBRANE_RECURSION_DEPTH + 16;
+      const deepObj: any = { level: 0 };
+      let current = deepObj;
+      for (let i = 1; i <= chainDepth; i++) {
+        current.nested = { level: i };
+        current = current.nested;
+      }
+
+      let node: any = createSecureProxy(deepObj);
+      expect(() => {
+        for (let i = 0; i <= chainDepth; i++) {
+          // A raw object would expose its constructor; the membrane must keep it undefined.
+          expect(node.constructor).toBeUndefined();
+          node = node.nested;
+        }
+      }).toThrow(/recursion depth/i);
     });
   });
 

--- a/libs/core/src/__tests__/secure-proxy.spec.ts
+++ b/libs/core/src/__tests__/secure-proxy.spec.ts
@@ -632,6 +632,62 @@ describe('createSafeReflect', () => {
     // When calling undefined as a function, it throws TypeError
     expect(safeReflect?.setPrototypeOf).toBeUndefined();
   });
+
+  // Regression: createSafeReflect used to hand back the RAW native Reflect methods, whose
+  // prototype chain reaches the host Function constructor, and Reflect.get was an unrestricted
+  // reflection primitive (string-literal key evades the AST guards).
+  it('does not hand back a raw Reflect.get that can reach the Function constructor', () => {
+    const safeReflect = createSafeReflect('STANDARD') as any;
+    const get = safeReflect.get;
+    expect(typeof get).toBe('function');
+    // The returned method is behind the membrane: its constructor is blocked.
+    expect(get.constructor).toBeUndefined();
+    // Reflect.get(Reflect.get, 'constructor') must not yield a usable Function constructor.
+    expect(get(get, 'constructor')).toBeUndefined();
+  });
+
+  it('still performs reflection correctly after hardening', () => {
+    const safeReflect = createSafeReflect('STANDARD') as any;
+    const obj = { a: 1, b: 2 };
+    expect(safeReflect.get(obj, 'a')).toBe(1);
+    expect(safeReflect.has(obj, 'b')).toBe(true);
+    expect([...safeReflect.ownKeys(obj)]).toEqual(expect.arrayContaining(['a', 'b']));
+  });
+});
+
+describe('getOwnPropertyDescriptor trap must not leak raw references (review finding)', () => {
+  it('refuses an object-valued non-configurable, non-writable pinned property', () => {
+    const host: Record<string, unknown> = {};
+    Object.defineProperty(host, 'pinned', {
+      value: { leadsToHost: {} },
+      configurable: false,
+      writable: false,
+      enumerable: true,
+    });
+    const proxy = createSecureProxy(host);
+    expect(() => Object.getOwnPropertyDescriptor(proxy, 'pinned')).toThrow(/blocked|cannot be exposed/i);
+  });
+
+  it('still reports a primitive-valued pinned property via its descriptor', () => {
+    const host: Record<string, unknown> = {};
+    Object.defineProperty(host, 'VERSION', {
+      value: 7,
+      configurable: false,
+      writable: false,
+      enumerable: true,
+    });
+    const proxy = createSecureProxy(host);
+    expect(Object.getOwnPropertyDescriptor(proxy, 'VERSION')?.value).toBe(7);
+  });
+
+  it('wraps a configurable object value so its descriptor cannot leak a raw reference', () => {
+    const obj = { child: { nested: 1 } };
+    const proxy = createSecureProxy(obj) as any;
+    const descriptor = Object.getOwnPropertyDescriptor(proxy, 'child');
+    // The descriptor value is itself a secure proxy: constructor is blocked.
+    expect(descriptor?.value.constructor).toBeUndefined();
+    expect(descriptor?.value.nested).toBe(1);
+  });
 });
 
 describe('BLOCKED_PROPERTY_CATEGORIES', () => {

--- a/libs/core/src/__tests__/secure-proxy.spec.ts
+++ b/libs/core/src/__tests__/secure-proxy.spec.ts
@@ -688,6 +688,41 @@ describe('getOwnPropertyDescriptor trap must not leak raw references (review fin
     expect(descriptor?.value.constructor).toBeUndefined();
     expect(descriptor?.value.nested).toBe(1);
   });
+
+  it('refuses a non-configurable accessor descriptor (cannot be wrapped under the invariant)', () => {
+    const obj: Record<string, unknown> = {};
+    Object.defineProperty(obj, 'danger', {
+      get() {
+        return 1;
+      },
+      configurable: false,
+      enumerable: true,
+    });
+    const proxy = createSecureProxy(obj);
+    expect(() => Object.getOwnPropertyDescriptor(proxy, 'danger')).toThrow(/blocked|cannot be exposed/i);
+  });
+
+  it('proxies a configurable accessor getter/setter so the descriptor cannot leak a raw function', () => {
+    const obj: Record<string, unknown> = {};
+    // eslint-disable-next-line accessor-pairs
+    Object.defineProperty(obj, 'value', {
+      get() {
+        return 42;
+      },
+      set() {
+        /* no-op */
+      },
+      configurable: true,
+      enumerable: true,
+    });
+    const proxy = createSecureProxy(obj) as any;
+    const descriptor = Object.getOwnPropertyDescriptor(proxy, 'value');
+    expect(typeof descriptor?.get).toBe('function');
+    // The getter is behind the membrane: its constructor is blocked (no raw host function leak).
+    expect((descriptor?.get as any).constructor).toBeUndefined();
+    expect(typeof descriptor?.set).toBe('function');
+    expect((descriptor?.set as any).constructor).toBeUndefined();
+  });
 });
 
 describe('BLOCKED_PROPERTY_CATEGORIES', () => {

--- a/libs/core/src/double-vm/parent-vm-bootstrap.ts
+++ b/libs/core/src/double-vm/parent-vm-bootstrap.ts
@@ -449,8 +449,15 @@ ${stackTraceHardeningCode}
         if (typeof value === 'function') {
           // Bind methods to preserve internal slots when relevant.
           try { value = value.bind(target); } catch (e) {}
+          return __ag_createSecureProxy(value, depth + 1);
         }
-        return __ag_createSecureProxy(value, depth + 1);
+        // Only objects still need proxying; primitives (e.g. length/name) are inert and must be
+        // returned directly, so a deep chain cannot turn a safe primitive read into a
+        // recursion-depth error.
+        if (value !== null && typeof value === 'object') {
+          return __ag_createSecureProxy(value, depth + 1);
+        }
+        return value;
 	      },
 	      apply: function(target, thisArg, args) {
 	        return __ag_Reflect.apply(target, thisArg, args);
@@ -1001,6 +1008,17 @@ ${stackTraceHardeningCode}
           return descriptor;
         }
 
+        // Accessor descriptors expose raw getter/setter functions. A non-configurable accessor
+        // must be reported with its exact get/set (proxy invariant) and so cannot be wrapped —
+        // deny it if it carries a function whose prototype chain reaches the host constructor.
+        if (descriptor && !descriptor.configurable &&
+            (typeof descriptor.get === 'function' || typeof descriptor.set === 'function')) {
+          throw createSafeError(
+            "Security violation: Access to property descriptor for '" + propName + "' is blocked. " +
+            "This property cannot be exposed without breaking the sandbox barrier."
+          );
+        }
+
         // Must return actual descriptor for other non-configurable properties (proxy invariant)
         if (descriptor && !descriptor.configurable) {
           return descriptor;
@@ -1015,6 +1033,16 @@ ${stackTraceHardeningCode}
             );
           }
           return undefined;
+        }
+
+        // A configurable accessor's getter/setter may be safely proxied so the descriptor never
+        // hands back a raw function that leads to the host Function constructor.
+        if (descriptor && (typeof descriptor.get === 'function' || typeof descriptor.set === 'function')) {
+          var accessorWrapped = {};
+          for (var ak in descriptor) { if (Object.prototype.hasOwnProperty.call(descriptor, ak)) accessorWrapped[ak] = descriptor[ak]; }
+          if (typeof descriptor.get === 'function') accessorWrapped.get = createSecureProxy(descriptor.get, depth + 1, host);
+          if (typeof descriptor.set === 'function') accessorWrapped.set = createSecureProxy(descriptor.set, depth + 1, host);
+          return accessorWrapped;
         }
 
         // Wrap object/function values so a descriptor read cannot hand back a raw reference that

--- a/libs/core/src/double-vm/parent-vm-bootstrap.ts
+++ b/libs/core/src/double-vm/parent-vm-bootstrap.ts
@@ -984,7 +984,23 @@ ${stackTraceHardeningCode}
         var propName = String(property);
         var descriptor = Reflect.getOwnPropertyDescriptor(target, property);
 
-        // Must return actual descriptor for non-configurable properties (proxy invariant)
+        // Mirror the get trap's host-owned pinned-value refusal: a non-configurable, non-writable
+        // data property must be reported with its exact value (proxy invariant), so on a HOST-owned
+        // value an object/function would cross the barrier unwrapped via descriptor.value and its
+        // prototype chain reaches the host Function constructor. Deny the read instead (throwing
+        // satisfies the invariant); primitives stay safe to report.
+        if (host && descriptor && !descriptor.configurable && descriptor.writable === false && 'value' in descriptor) {
+          var exactValue = descriptor.value;
+          if (exactValue !== null && (typeof exactValue === 'object' || typeof exactValue === 'function')) {
+            throw createSafeError(
+              "Security violation: Access to property descriptor for '" + propName + "' is blocked. " +
+              "This property cannot be exposed without breaking the sandbox barrier."
+            );
+          }
+          return descriptor;
+        }
+
+        // Must return actual descriptor for other non-configurable properties (proxy invariant)
         if (descriptor && !descriptor.configurable) {
           return descriptor;
         }
@@ -998,6 +1014,18 @@ ${stackTraceHardeningCode}
             );
           }
           return undefined;
+        }
+
+        // Wrap object/function values so a descriptor read cannot hand back a raw reference that
+        // the get trap would otherwise have proxied.
+        if (descriptor && 'value' in descriptor) {
+          var value = descriptor.value;
+          if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
+            var wrapped = {};
+            for (var dk in descriptor) { if (Object.prototype.hasOwnProperty.call(descriptor, dk)) wrapped[dk] = descriptor[dk]; }
+            wrapped.value = createSecureProxy(value, depth + 1, host);
+            return wrapped;
+          }
         }
         return descriptor;
       },

--- a/libs/core/src/double-vm/parent-vm-bootstrap.ts
+++ b/libs/core/src/double-vm/parent-vm-bootstrap.ts
@@ -422,9 +422,10 @@ ${stackTraceHardeningCode}
 	    if (depth === undefined) depth = 0;
 	    if (!__ag_Proxy || !__ag_Reflect) return obj;
 	    // Fail CLOSED past the recursion backstop: returning the raw target would leak an
-	    // unwrapped reference (see MEMBRANE_MAX_RECURSION_DEPTH).
+	    // unwrapped reference (see MEMBRANE_MAX_RECURSION_DEPTH). Use the hardened safe-error
+	    // helper (sanitized stack, nulled constructor/proto) rather than a raw Error.
 	    if (depth > ${MEMBRANE_MAX_RECURSION_DEPTH}) {
-	      throw new Error('Security violation: secure-proxy recursion depth exceeded.');
+	      throw __ag_createSafeError('Security violation: secure-proxy recursion depth exceeded.');
 	    }
 	    if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) return obj;
 

--- a/libs/core/src/double-vm/parent-vm-bootstrap.ts
+++ b/libs/core/src/double-vm/parent-vm-bootstrap.ts
@@ -15,6 +15,22 @@ import type { SerializableParentValidationConfig, SerializableSuspiciousPattern 
 import type { SecurityLevel } from '../types';
 
 /**
+ * Recursion backstop for the in-VM secure-proxy membranes.
+ *
+ * The counter is a stack-safety limit, NOT a security control: every membrane level already
+ * blocks the dangerous properties, so this number never decides whether an escape is possible.
+ * Exceeding it must fail CLOSED (throw) — returning the raw target used to hand sandbox code an
+ * unwrapped host reference (the reported `.bind`-chain escape inflated the counter past the old
+ * cap of 10 and received a raw function whose chain reaches the host Function constructor).
+ * It sits well above the deepest value that can legitimately arrive (a tool result is
+ * pre-sanitized to at most `maxSanitizeDepth`, which peaks at 50; custom host globals are not
+ * sanitize-bounded, hence the generous ~5x headroom) so legitimate data is never rejected. The
+ * membrane is lazy (one property access = one wrap = O(1) synchronous stack), so a large value
+ * costs nothing in stack depth or performance.
+ */
+const MEMBRANE_MAX_RECURSION_DEPTH = 256;
+
+/**
  * Options for generating the parent VM bootstrap script
  */
 export interface ParentVmBootstrapOptions {
@@ -405,7 +421,11 @@ ${stackTraceHardeningCode}
 	  function __ag_createSecureProxy(obj, depth) {
 	    if (depth === undefined) depth = 0;
 	    if (!__ag_Proxy || !__ag_Reflect) return obj;
-	    if (depth > 10) return obj;
+	    // Fail CLOSED past the recursion backstop: returning the raw target would leak an
+	    // unwrapped reference (see MEMBRANE_MAX_RECURSION_DEPTH).
+	    if (depth > ${MEMBRANE_MAX_RECURSION_DEPTH}) {
+	      throw new Error('Security violation: secure-proxy recursion depth exceeded.');
+	    }
 	    if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) return obj;
 
 	    if (__ag_proxyCache) {
@@ -853,7 +873,14 @@ ${stackTraceHardeningCode}
   function createSecureProxy(obj, depth, host) {
     if (depth === undefined) depth = 0;
     host = host === true;
-    if (depth > 10) return obj; // Max depth to prevent infinite recursion
+    // Recursion backstop. Fail CLOSED: returning the raw target here was the reported escape.
+    // A bind chain inflates depth (each read binds a FRESH function, so the identity cache never
+    // dedupes it) past the cap, and the raw host function prototype chain reaches the host
+    // Function constructor for RCE. Throwing keeps the membrane total; the cap sits far above any
+    // legitimately-deep (pre-sanitized) value so real data is never rejected.
+    if (depth > ${MEMBRANE_MAX_RECURSION_DEPTH}) {
+      throw createSafeError('Security violation: secure-proxy recursion depth exceeded.');
+    }
 
     // Skip primitives and null
     if (obj === null || typeof obj !== 'object' && typeof obj !== 'function') {

--- a/libs/core/src/enclave.ts
+++ b/libs/core/src/enclave.ts
@@ -31,7 +31,12 @@ import {
   type MultiFileTransformResult,
 } from './babel';
 import { transformAgentScript, isWrappedInMain } from '@enclave-vm/ast';
-import { extractLargeStrings, transformConcatenation, transformTemplateLiterals } from '@enclave-vm/ast';
+import {
+  extractLargeStrings,
+  transformConcatenation,
+  transformTemplateLiterals,
+  guardComputedMemberKeys,
+} from '@enclave-vm/ast';
 import * as acorn from 'acorn';
 import { generate } from 'astring';
 import type {
@@ -52,6 +57,7 @@ import type {
 import type { WorkerPoolConfig } from './adapters/worker-pool';
 import { SECURITY_LEVEL_CONFIGS, DEFAULT_DOUBLE_VM_CONFIG } from './types';
 import { validateGlobals } from './globals-validator';
+import { buildBlockedPropertiesFromConfig } from './secure-proxy';
 import { ReferenceSidecar } from './sidecar';
 import { REFERENCE_CONFIGS, ReferenceConfig } from './sidecar';
 import { ScoringGate, ScoringGateResult } from './scoring';
@@ -431,6 +437,15 @@ export class Enclave {
         transformedCode = this.applyMemoryTrackingTransforms(transformedCode);
       }
 
+      // Step 2.2: Runtime computed-key guard (defense-in-depth for weakness 1).
+      // Runs AFTER validation so it neither masks the static rules nor trips them on its injected
+      // helper. Wraps dynamic computed member keys so `obj[expr]` checks the RESOLVED key at
+      // runtime, catching dangerous names built via `String.fromCharCode(...)`, concatenation,
+      // etc. that static analysis cannot resolve.
+      if (this.transformCode) {
+        transformedCode = this.applyComputedKeyGuard(transformedCode);
+      }
+
       // Step 2.5: AI Scoring Gate (if configured)
       // This runs AFTER AST validation but BEFORE code execution
       let scoringResult: ScoringGateResult | undefined;
@@ -548,6 +563,27 @@ export class Enclave {
    * @param code The code to transform
    * @returns The transformed code
    */
+  private applyComputedKeyGuard(code: string): string {
+    // Mirror the runtime membrane's policy for this security level: refuse the same keys, and
+    // yield undefined instead of throwing when the level does not throw on blocked access.
+    const proxyConfig = this.config.secureProxyConfig;
+    const blockedKeys = [...buildBlockedPropertiesFromConfig(proxyConfig)];
+    if (blockedKeys.length === 0) {
+      return code;
+    }
+    const throwOnBlocked = proxyConfig.throwOnBlocked ?? true;
+
+    const parseModule = (source: string): acorn.Node =>
+      acorn.parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) as unknown as acorn.Node;
+
+    const ast = parseModule(code);
+    const { guardedCount } = guardComputedMemberKeys(ast, parseModule, { blockedKeys, throwOnBlocked });
+    if (guardedCount === 0) {
+      return code;
+    }
+    return generate(ast);
+  }
+
   private applyMemoryTrackingTransforms(code: string): string {
     // Parse the code into an AST
     const ast = acorn.parse(code, {

--- a/libs/core/src/secure-proxy.ts
+++ b/libs/core/src/secure-proxy.ts
@@ -491,7 +491,12 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
   // Floor it so the (fail-closed) recursion cap can never sit below the deepest value that can
   // legitimately arrive; a higher cap only wraps MORE of the graph, so it is never less secure.
   const configuredMaxDepth = options.maxDepth ?? options.levelConfig?.proxyMaxDepth ?? 10;
-  const maxDepth = Math.max(configuredMaxDepth, MIN_MEMBRANE_RECURSION_DEPTH);
+  // A non-finite value (NaN/Infinity) would make `depth > maxDepth` never trip, silently
+  // disabling the fail-closed backstop — reject it and fall back to the floor. Valid values are
+  // floored so the cap can never sit below the deepest value that can legitimately arrive.
+  const maxDepth = Number.isFinite(configuredMaxDepth)
+    ? Math.max(configuredMaxDepth, MIN_MEMBRANE_RECURSION_DEPTH)
+    : MIN_MEMBRANE_RECURSION_DEPTH;
 
   // Use throwOnBlocked from options or levelConfig (options takes precedence)
   const throwOnBlocked = options.throwOnBlocked ?? options.levelConfig?.throwOnBlocked ?? false;

--- a/libs/core/src/secure-proxy.ts
+++ b/libs/core/src/secure-proxy.ts
@@ -19,6 +19,24 @@ import type { SecureProxyLevelConfig, SecurityLevel } from './types';
 import { createSafeError } from './safe-error';
 
 /**
+ * Absolute floor for the membrane recursion cap.
+ *
+ * The recursion counter is a stack-safety backstop, NOT a security control: every level of the
+ * membrane already blocks the dangerous properties, so the cap value never decides whether an
+ * escape is possible. Its only job is to stop pathological recursion. It must therefore sit
+ * comfortably above the deepest value that can legitimately reach the membrane (a tool result is
+ * pre-sanitized to at most `maxSanitizeDepth`, which peaks at 50), or legitimate deep data would
+ * be rejected (custom host globals are not sanitize-bounded, hence the generous ~5x headroom).
+ * The membrane is lazy (one property access = one wrap = O(1) synchronous stack), so a large
+ * value costs nothing. Exceeding the cap fails CLOSED (throws) — it must never hand back a raw
+ * target.
+ *
+ * Exported so tests can derive their traversal depth from the real cap instead of hardcoding a
+ * value that would silently rot if the cap changed.
+ */
+export const MIN_MEMBRANE_RECURSION_DEPTH = 256;
+
+/**
  * Categorized blocked properties for defense-in-depth
  *
  * Organized by attack category to support per-security-level configuration
@@ -458,8 +476,11 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
   // Add any additional blocked properties
   const blockedSet = new Set([...baseBlocked, ...(options.additionalBlocked || [])]);
 
-  // Use maxDepth from levelConfig if provided, otherwise from options or default
-  const maxDepth = options.maxDepth ?? options.levelConfig?.proxyMaxDepth ?? 10;
+  // Use maxDepth from levelConfig if provided, otherwise from options or default.
+  // Floor it so the (fail-closed) recursion cap can never sit below the deepest value that can
+  // legitimately arrive; a higher cap only wraps MORE of the graph, so it is never less secure.
+  const configuredMaxDepth = options.maxDepth ?? options.levelConfig?.proxyMaxDepth ?? 10;
+  const maxDepth = Math.max(configuredMaxDepth, MIN_MEMBRANE_RECURSION_DEPTH);
 
   // Use throwOnBlocked from options or levelConfig (options takes precedence)
   const throwOnBlocked = options.throwOnBlocked ?? options.levelConfig?.throwOnBlocked ?? false;
@@ -480,9 +501,15 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
       }
     }
 
-    // Depth limit to prevent stack overflow
+    // Recursion backstop. Fail CLOSED: returning the raw target here would hand sandbox code an
+    // unwrapped reference whose prototype chain reaches the host Function constructor (the
+    // reported `.bind`-chain / deep-graph escape). Throwing keeps the membrane total.
     if (depth > maxDepth) {
-      return obj;
+      throw createSafeError(
+        `Security violation: secure-proxy recursion depth (${maxDepth}) exceeded. ` +
+          `The value cannot be exposed without breaking the sandbox barrier.`,
+        'SecurityError',
+      );
     }
 
     const proxy = new Proxy(obj, {

--- a/libs/core/src/secure-proxy.ts
+++ b/libs/core/src/secure-proxy.ts
@@ -695,6 +695,21 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
           return descriptor;
         }
 
+        // Accessor descriptors expose raw getter/setter functions. A non-configurable accessor
+        // must be reported with its exact get/set (proxy invariant), so it cannot be wrapped —
+        // deny it if it carries a function whose prototype chain reaches the host constructor.
+        if (
+          descriptor &&
+          !descriptor.configurable &&
+          (typeof descriptor.get === 'function' || typeof descriptor.set === 'function')
+        ) {
+          throw createSafeError(
+            `Security violation: Access to property descriptor for '${String(propName)}' is blocked. ` +
+              `This property cannot be exposed without breaking the sandbox barrier.`,
+            'SecurityError',
+          );
+        }
+
         // Must return actual descriptor for other non-configurable properties (proxy invariant)
         if (descriptor && !descriptor.configurable) {
           return descriptor;
@@ -713,6 +728,16 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
             );
           }
           return undefined;
+        }
+
+        // A configurable accessor's getter/setter may be safely proxied so the descriptor never
+        // hands back a raw function whose prototype chain reaches the host Function constructor.
+        if (descriptor && (typeof descriptor.get === 'function' || typeof descriptor.set === 'function')) {
+          return {
+            ...descriptor,
+            get: typeof descriptor.get === 'function' ? proxyWithDepth(descriptor.get, depth + 1) : descriptor.get,
+            set: typeof descriptor.set === 'function' ? proxyWithDepth(descriptor.set, depth + 1) : descriptor.set,
+          };
         }
 
         // Wrap object/function values so a descriptor read cannot hand back a raw reference that

--- a/libs/core/src/secure-proxy.ts
+++ b/libs/core/src/secure-proxy.ts
@@ -219,7 +219,7 @@ export function createSafeReflect(securityLevel: SecurityLevel): typeof Reflect 
 
       // Wrap Reflect.construct to block Function constructors
       if (typeof value === 'function' && prop === 'construct') {
-        return function (ctorTarget: unknown, args: unknown[], newTarget?: unknown) {
+        const safeConstruct = function (ctorTarget: unknown, args: unknown[], newTarget?: unknown) {
           // Block Function, AsyncFunction, GeneratorFunction, AsyncGeneratorFunction constructors
           // Intentional empty functions to obtain constructor references
           // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -243,6 +243,17 @@ export function createSafeReflect(securityLevel: SecurityLevel): typeof Reflect 
             newTarget as new (...args: unknown[]) => unknown,
           );
         };
+        // Wrap so the returned function cannot itself be walked to the host Function constructor.
+        return createSecureProxy(safeConstruct);
+      }
+
+      // SECURITY: never hand back the RAW native Reflect methods. Each is a host-realm function
+      // whose prototype chain reaches the host Function constructor, and Reflect.get /
+      // Reflect.getOwnPropertyDescriptor are reflection primitives whose STRING-LITERAL key
+      // argument bypasses the AST computed-key guard. Wrapping in a secure proxy blocks
+      // `.constructor` on the method and keeps every result behind the membrane.
+      if (typeof value === 'function') {
+        return createSecureProxy(value);
       }
 
       return value;
@@ -663,7 +674,23 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
         const propName = typeof property === 'symbol' ? property.toString() : property;
         const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
 
-        // Must return actual descriptor for non-configurable properties (proxy invariant)
+        // Mirror the get trap: a non-configurable, non-writable data property must be reported
+        // with its exact value (proxy invariant), so an object/function value cannot be wrapped
+        // or hidden and would cross the barrier unwrapped via `descriptor.value`. Deny the read
+        // instead (throwing satisfies the invariant); primitives are inert and safe to report.
+        if (descriptor && !descriptor.configurable && descriptor.writable === false && 'value' in descriptor) {
+          const exactValue: unknown = descriptor.value;
+          if (exactValue !== null && (typeof exactValue === 'object' || typeof exactValue === 'function')) {
+            throw createSafeError(
+              `Security violation: Access to property descriptor for '${String(propName)}' is blocked. ` +
+                `This property cannot be exposed without breaking the sandbox barrier.`,
+              'SecurityError',
+            );
+          }
+          return descriptor;
+        }
+
+        // Must return actual descriptor for other non-configurable properties (proxy invariant)
         if (descriptor && !descriptor.configurable) {
           return descriptor;
         }
@@ -681,6 +708,15 @@ export function createSecureProxy<T extends object>(target: T, options: SecurePr
             );
           }
           return undefined;
+        }
+
+        // Wrap object/function values so a descriptor read cannot hand back a raw reference that
+        // the get trap would have proxied (a configurable property's value may be safely wrapped).
+        if (descriptor && 'value' in descriptor) {
+          const value: unknown = descriptor.value;
+          if (value !== null && (typeof value === 'object' || typeof value === 'function')) {
+            return { ...descriptor, value: proxyWithDepth(value as object, depth + 1) };
+          }
         }
 
         return descriptor;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added runtime guarding for dynamic computed property access to block constructor/prototype lookups, including reconstructed and “laundered” keys.
  * Strengthened the secure-proxy membrane recursion to **fail closed** at a deeper threshold (256) to prevent returning unwrapped references.
  * Hardened safe reflection, including wrapping function results and tightening `getOwnPropertyDescriptor` to block descriptor-based escape paths.
* **Bug Fixes**
  * Blocked additional bind-chain and computed-key escape attempts and reduced false positives for benign computed indexing/keys.
* **Tests**
  * Expanded regression coverage for the above scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->